### PR TITLE
Render images in Preview

### DIFF
--- a/src/blueprints/base.ts
+++ b/src/blueprints/base.ts
@@ -19,7 +19,7 @@ import {
     MarkdownPostProcessorContext,
     MarkdownPreviewRenderer,
     MarkdownRenderChild,
-    MarkdownRenderer,
+    MarkdownRenderer, MarkdownView, TFile,
 } from 'obsidian'
 import { Parser } from 'peggy'
 
@@ -272,6 +272,7 @@ export abstract class CodeBlockBlueprint extends Blueprint {
         // Add front
         const frontEl = fieldsEl.createDiv('ankibridge-card-front ankibridge-card-content')
         MarkdownRenderer.renderMarkdown(front, frontEl, ctx.sourcePath, renderChild)
+        this.includeImages(frontEl);
 
         // Add back
         if (back !== null) {
@@ -279,9 +280,30 @@ export abstract class CodeBlockBlueprint extends Blueprint {
 
             const backEl = fieldsEl.createDiv('ankibridge-card-back ankibridge-card-content')
             MarkdownRenderer.renderMarkdown(back, backEl, ctx.sourcePath, renderChild)
+            this.includeImages(backEl)
         }
 
+
+
+
         return renderChild
+    }
+
+
+
+    public includeImages(element: HTMLElement) {
+        element.findAll(".internal-embed").forEach(el => {
+            const src = el.getAttribute("src");
+            const target = this.app.vault.getAbstractFileByPath("Attachments/" + src)
+            if (target instanceof TFile && target.extension !== "md") {
+                el.innerText = '';
+                el.createEl("img", {attr: {src: this.app.vault.getResourcePath(target)}}, img => {
+                    if (el.hasAttribute("width")) img.setAttribute("width", el.getAttribute("width")?? "")
+                    if (el.hasAttribute("alt"))   img.setAttribute("alt",   el.getAttribute("alt")?? "")
+                })
+                el.addClasses(["image-embed", "is-loaded"]);
+            }
+        });
     }
 
     public async renderErrorCard(

--- a/src/blueprints/base.ts
+++ b/src/blueprints/base.ts
@@ -272,7 +272,7 @@ export abstract class CodeBlockBlueprint extends Blueprint {
         // Add front
         const frontEl = fieldsEl.createDiv('ankibridge-card-front ankibridge-card-content')
         MarkdownRenderer.renderMarkdown(front, frontEl, ctx.sourcePath, renderChild)
-        this.includeImages(frontEl);
+        this.includeImages(frontEl, ctx.sourcePath);
 
         // Add back
         if (back !== null) {
@@ -280,7 +280,7 @@ export abstract class CodeBlockBlueprint extends Blueprint {
 
             const backEl = fieldsEl.createDiv('ankibridge-card-back ankibridge-card-content')
             MarkdownRenderer.renderMarkdown(back, backEl, ctx.sourcePath, renderChild)
-            this.includeImages(backEl)
+            this.includeImages(backEl, ctx.sourcePath)
         }
 
 
@@ -290,12 +290,12 @@ export abstract class CodeBlockBlueprint extends Blueprint {
     }
 
 
-
-    public includeImages(element: HTMLElement) {
+    public includeImages(element: HTMLElement, sourcePath: string) {
         element.findAll(".internal-embed").forEach(el => {
             const src = el.getAttribute("src");
-            const target = this.app.vault.getAbstractFileByPath("Attachments/" + src)
-            if (target instanceof TFile && target.extension !== "md") {
+            if (src === null) return;
+            const target: TFile|null = this.app.metadataCache.getFirstLinkpathDest(src, sourcePath);
+            if (target !== null && target.extension !== "md") {
                 el.innerText = '';
                 el.createEl("img", {attr: {src: this.app.vault.getResourcePath(target)}}, img => {
                     if (el.hasAttribute("width")) img.setAttribute("width", el.getAttribute("width")?? "")


### PR DESCRIPTION
Hallo there,

I really like this plugin! But for my convenience I needed the images to be rendered in Live Preview (#20). As I needed this rather quickly to  cram a bit for an upcoming exam I quickly implemented it.

The baseline for my implementation is the code used in the [obsidian kanban](https://github.com/mgmeyers/obsidian-kanban/pull/134/commits/fe5382798d26c887658581e5aedb6ed5102f42ed) as they faced the same problem. 

The solution relies on removing the innertext of the element where the image should be and adding an HTML image with the correct source, width and height, as a child node.