### PR TITLE
Feature: Add note type Basic (and reversed card)

### DIFF
--- a/sass/card.scss
+++ b/sass/card.scss
@@ -91,6 +91,7 @@ div.ankibridge-card {
 
                 // Boolean properties
                 &[data-type="cloze"],
+                &[data-type="reversed"],
                 &[data-type="enabled"],
                 &[data-type="delete"] {
                     font-size : 0;
@@ -113,6 +114,10 @@ div.ankibridge-card {
 
                 &[data-type="cloze"]::before {
                     content: "Cloze";
+                }
+
+                &[data-type="reversed"]::before {
+                    content: "Reversed Card";
                 }
 
                 &[data-type="enabled"]::before {

--- a/src/blueprints/basic-codeblock.ts
+++ b/src/blueprints/basic-codeblock.ts
@@ -39,6 +39,7 @@ export class BasicCodeBlockBlueprint extends CodeBlockBlueprint {
             delete: note.config.delete,
             enabled: note.config.enabled,
             cloze: note.config.cloze,
+            reversed: note.config.reversed,
         })
 
         let str = ''

--- a/src/blueprints/sandwich.ts
+++ b/src/blueprints/sandwich.ts
@@ -30,6 +30,7 @@ export class SandwichBlueprint extends Blueprint {
             delete: note.config.delete,
             enabled: note.config.enabled,
             cloze: note.config.cloze,
+            reversed: note.config.reversed,
         })
 
         let str = ''

--- a/src/entities/note.ts
+++ b/src/entities/note.ts
@@ -14,7 +14,7 @@ export enum NoteField {
 }
 export type NoteFields = Record<NoteField, string | null>
 
-export type ModelName = 'Basic' | 'Cloze'
+export type ModelName = 'Basic' | 'Basic (and reversed card)' | 'Cloze'
 
 export interface SourceDescriptor {
     from: number

--- a/src/notes/base.ts
+++ b/src/notes/base.ts
@@ -20,6 +20,7 @@ export interface Config {
     delete?: boolean
     enabled?: boolean
     cloze?: boolean
+    reversed?: boolean
 }
 
 export interface ParseConfig extends Config {
@@ -42,6 +43,7 @@ export const ParseConfigSchema: yup.SchemaOf<ParseConfig> = yup.object({
     delete: yup.boolean().nullAsUndefined(),
     enabled: yup.boolean().nullAsUndefined(),
     cloze: yup.boolean().nullAsUndefined(),
+    reversed: yup.boolean().nullAsUndefined(),
 })
 
 // Location
@@ -154,7 +156,9 @@ export abstract class NoteBase {
         if (this.isCloze) {
             return 'Cloze'
         }
-
+        else if (this.config.reversed) {
+            return 'Basic (and reversed card)'
+        }
         return 'Basic'
     }
 


### PR DESCRIPTION
I often use this note type, so I made a small change to add it to the plugin. Thanks for building this plugin and making it available! Let me know if you find the time to incorporate the changes, so I/we can add the feature to the documentation. If changes are needed, just let me know.

This commit adds a boolean parameter `reversed` to the configuration. If the note type is not cloze and `reversed` is set to `true`, the note type will be set to "Basic (and reversed card)" instead of "Basic". As this is a standard note type, it should be available on all Anki installations. As the fields are identical to the Basic type, no unexpected problems should arise.